### PR TITLE
Update jquery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/cloudinary/cloudinary_js/issues"
   },
   "homepage": "https://github.com/cloudinary/cloudinary_js",
-  "dependencies": {
-	  "jquery": "^2.2.4",
+  "peerDependencies": {
+	  "jquery": ">=2.2.4",
 	  "blueimp-file-upload": "^9.11.2"
   }
 


### PR DESCRIPTION
Updated package.json :
- set library compatible with jQuery version 3
- use of peerDependencies instead of dependencies (allows NPM to warn the user if two different versions of jQuery need to be installed)